### PR TITLE
Adding a time range functionality to extract records from biorxiv and…

### DIFF
--- a/paperscraper/get_dumps/biorxiv.py
+++ b/paperscraper/get_dumps/biorxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -15,20 +16,29 @@ save_path = os.path.join(
 )
 
 
-def biorxiv(save_path: str = save_path):
-    """Fetches all papers from biorxiv until current date, stores them in jsonl
-    format in save_path.
+def biorxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
+    """Fetches papers from biorxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, papers will be fetched from biorxiv 
+    from the launch date of biorxiv until the current date. The fetched papers will be 
+    stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = BioRxivApi()
 
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))

--- a/paperscraper/get_dumps/medrxiv.py
+++ b/paperscraper/get_dumps/medrxiv.py
@@ -2,6 +2,7 @@
 import json
 import os
 from datetime import datetime
+from typing import Optional
 
 import pkg_resources
 from tqdm import tqdm
@@ -13,19 +14,28 @@ save_folder = pkg_resources.resource_filename("paperscraper", "server_dumps")
 save_path = os.path.join(save_folder, f"medrxiv_{today}.jsonl")
 
 
-def medrxiv(save_path: str = save_path):
-    """Fetches all papers from medrxiv until current date, stores them in jsonl
-    format in save_path.
+def medrxiv(
+        begin_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        save_path: str = save_path):
+    """Fetches papers from medrxiv based on time range, i.e., begin_date and end_date. 
+    If the begin_date and end_date are not provided, then papers will be fetched from 
+    medrxiv starting from the launch date of medrxiv until current date. The fetched 
+    papers will be stored in jsonl format in save_path.
 
     Args:
         save_path (str, optional): Path where the dump is stored.
             Defaults to save_path.
+        begin_date (Optional[str], optional): begin date expressed as YYYY-MM-DD. 
+            Defaults to None.
+        end_date (Optional[str], optional): end date expressed as YYYY-MM-DD.
+            Defaults to None.
     """
     # create API client
     api = MedRxivApi()
     # dump all papers
     with open(save_path, "w") as fp:
-        for index, paper in enumerate(tqdm(api.get_papers())):
+        for index, paper in enumerate(tqdm(api.get_papers(begin_date=begin_date, end_date=end_date))):
             if index > 0:
                 fp.write(os.linesep)
             fp.write(json.dumps(paper))


### PR DESCRIPTION
… medrxiv. (#24)

* During the bulk extraction of the biorxiv and medrxiv, earlier the code used to start from the launch_date till today's date. If the script fails in between due to the connection error then starting the script will override the previous collected information and would start from launch_date. Thus, a functionality is added to provide a begin_date and end_date parameter to the biorxiv and medrxvi script.

* Updated the docstring for the biorxiv and medrxiv function with the begin_date and end_date parameters

---------